### PR TITLE
CENTREO-1: React router addition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+Verson: 0.0.2
+Date: 2019-04-05
+Branch: add-routes
+Dev: Ivan
+
+## Added
+
+-   React-router-dom
+-   Changelog to reflect iterations of changes
+-   error page for testing
+
+## Changed
+
+-   branch name from "non_incorporation_pages" to "add-routes"
+-   Moved incorporation into a page nested under "DefaultRoutes"
+
+## Removed

--- a/package.json
+++ b/package.json
@@ -3,12 +3,14 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@types/react-router-dom": "^4.3.1",
     "@types/reactstrap": "^7.1.3",
     "@types/yup": "^0.26.12",
     "bootstrap": "^4.3.1",
     "formik": "^1.5.1",
     "react": "^16.8.5",
     "react-dom": "^16.8.5",
+    "react-router-dom": "^5.0.0",
     "react-scripts-ts": "3.1.0",
     "reactstrap": "^7.1.0",
     "yup": "^0.27.0"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,22 +1,31 @@
-import 'bootstrap/dist/css/bootstrap.min.css';
-import * as React from 'react';
-import './App.css';
-import Footer from './components/Footer';
-import Header from './components/Header';
-import MasterForm from './components/MasterForm';
-import './styles/all.min.css';
+// Module imports
+import * as React from "react";
 
+// Styling imports
+import "bootstrap/dist/css/bootstrap.min.css";
+import "./App.css";
+import "./styles/all.min.css";
+
+// Component imports
+// import Footer from "./components/Footer";
+// import Header from "./components/Header";
+// import MasterForm from "./components/MasterForm";
+
+// Routes imports
+import DefaultRoutes from "./routes/defaultRoutes";
 
 class App extends React.Component {
-  public render() {
-    return (
-      <>
-        <Header />
+    public render() {
+        return (
+            <>
+                {/* First content testing */}
+                {/* <Header />
         <MasterForm />
-        <Footer />
-      </>
-    );
-  }
+        <Footer /> */}
+                <DefaultRoutes />
+            </>
+        );
+    }
 }
 
 export default App;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,11 +1,21 @@
-import * as React from 'react';
-import * as ReactDOM from 'react-dom';
-import App from './App';
-import './index.css';
-import registerServiceWorker from './registerServiceWorker';
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+import registerServiceWorker from "./registerServiceWorker";
+
+// Components
+import App from "./App";
+
+// Styling
+import "./index.css";
+
+// React router
+import { BrowserRouter as Router, Route } from "react-router-dom";
 
 ReactDOM.render(
-  <App />,
-  document.getElementById('root') as HTMLElement
+    <Router>
+        <Route component={App} />
+    </Router>,
+    document.getElementById("root") as HTMLElement
 );
+
 registerServiceWorker();

--- a/src/pages/3a.01-09 Incorporation/3a.01-09.tsx
+++ b/src/pages/3a.01-09 Incorporation/3a.01-09.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+
+// Style imports
+import "bootstrap/dist/css/bootstrap.min.css";
+import "src/App.css";
+import "src/styles/all.min.css";
+
+// Component inports
+import Footer from "src/components/Footer";
+import Header from "src/components/Header";
+import MasterForm from "src/components/MasterForm";
+
+export default class IncorporationProcess extends React.Component {
+    public render() {
+        return (
+            <>
+                <Header />
+                <MasterForm />
+                <Footer />
+            </>
+        );
+    }
+}

--- a/src/pages/error404/error404.tsx
+++ b/src/pages/error404/error404.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+
+// Style imports
+import "bootstrap/dist/css/bootstrap.min.css";
+import "src/App.css";
+import "src/styles/all.min.css";
+
+// Component inports
+
+export default class Error404 extends React.Component {
+    public render() {
+        return (
+            <div>
+                <h1>This is an error page.</h1>{" "}
+            </div>
+        );
+    }
+}

--- a/src/routes/defaultRoutes.tsx
+++ b/src/routes/defaultRoutes.tsx
@@ -1,0 +1,18 @@
+// Module imports
+import * as React from "react";
+import { Route, Switch } from "react-router-dom";
+
+// Import components
+import IncorporationProcess from "src/pages/3a.01-09 Incorporation/3a.01-09";
+import Error404 from "src/pages/error404/error404";
+
+export default class DefaultRoutes extends React.Component {
+    public render() {
+        return (
+            <Switch>
+                <Route exact={true} path="/" component={IncorporationProcess} />
+                <Route exact={true} path="/error404" component={Error404} />
+            </Switch>
+        );
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,6 +22,11 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@types/history@*":
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.2.tgz#0e670ea254d559241b6eeb3894f8754991e73220"
+  integrity sha512-ui3WwXmjTaY73fOQ3/m3nnajU/Orhi6cEu5rzX+BrAAJxa3eITXZ5ch9suPqtM03OWhAHhPSyBGCN4UKoxO20Q==
+
 "@types/jest-diff@*":
   version "20.0.1"
   resolved "https://registry.yarnpkg.com/@types/jest-diff/-/jest-diff-20.0.1.tgz#35cc15b9c4f30a18ef21852e255fdb02f6d59b89"
@@ -48,6 +53,23 @@
   version "16.8.3"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.8.3.tgz#6131b7b6158bc7ed1925a3374b88b7c00481f0cb"
   dependencies:
+    "@types/react" "*"
+
+"@types/react-router-dom@^4.3.1":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-4.3.1.tgz#71fe2918f8f60474a891520def40a63997dafe04"
+  integrity sha512-GbztJAScOmQ/7RsQfO4cd55RuH1W4g6V1gDW3j4riLlt+8yxYLqqsiMzmyuXBLzdFmDtX/uU2Bpcm0cmudv44A==
+  dependencies:
+    "@types/history" "*"
+    "@types/react" "*"
+    "@types/react-router" "*"
+
+"@types/react-router@*":
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-4.4.5.tgz#1166997dc7eef2917b5ebce890ebecb32ee5c1b3"
+  integrity sha512-12+VOu1+xiC8RPc9yrgHCyLI79VswjtuqeS2gPrMcywH6tkc8rGIUhs4LaL3AJPqo5d+RPnfRpNKiJ7MK2Qhcg==
+  dependencies:
+    "@types/history" "*"
     "@types/react" "*"
 
 "@types/react@*", "@types/react@^16.8.9":
@@ -3165,6 +3187,18 @@ he@1.2.x:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
 
+history@^4.9.0:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.9.0.tgz#84587c2068039ead8af769e9d6a6860a14fa1bca"
+  integrity sha512-H2DkjCjXf0Op9OAr6nJ56fcRkTSNrUiv41vNJ6IswJjif6wlpZK0BTfFbi7qK9dXLSYZxkq5lBsj3vUjlYBYZA==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    loose-envify "^1.2.0"
+    resolve-pathname "^2.2.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+    value-equal "^0.4.0"
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -3176,6 +3210,13 @@ hmac-drbg@^1.0.0:
 hoist-non-react-statics@^2.5.5:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
+
+hoist-non-react-statics@^3.1.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz#b09178f0122184fb95acf525daaecb4d8f45958b"
+  integrity sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==
+  dependencies:
+    react-is "^16.7.0"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -4477,7 +4518,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   dependencies:
@@ -5237,7 +5278,7 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
 
-path-to-regexp@^1.0.1:
+path-to-regexp@^1.0.1, path-to-regexp@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
   dependencies:
@@ -5848,6 +5889,11 @@ react-fast-compare@^2.0.1:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
 
+react-is@^16.6.0, react-is@^16.7.0:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
+  integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
+
 react-is@^16.8.1:
   version "16.8.5"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.5.tgz#c54ac229dd66b5afe0de5acbe47647c3da692ff8"
@@ -5862,6 +5908,35 @@ react-popper@^0.10.4:
   dependencies:
     popper.js "^1.14.1"
     prop-types "^15.6.1"
+
+react-router-dom@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.0.0.tgz#542a9b86af269a37f0b87218c4c25ea8dcf0c073"
+  integrity sha512-wSpja5g9kh5dIteZT3tUoggjnsa+TPFHSMrpHXMpFsaHhQkm/JNVGh2jiF9Dkh4+duj4MKCkwO6H08u6inZYgQ==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    history "^4.9.0"
+    loose-envify "^1.3.1"
+    prop-types "^15.6.2"
+    react-router "5.0.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+
+react-router@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.0.0.tgz#349863f769ffc2fa10ee7331a4296e86bc12879d"
+  integrity sha512-6EQDakGdLG/it2x9EaCt9ZpEEPxnd0OCLBHQ1AcITAAx7nCnyvnzf76jKWG1s2/oJ7SSviUgfWHofdYljFexsA==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    create-react-context "^0.2.2"
+    history "^4.9.0"
+    hoist-non-react-statics "^3.1.0"
+    loose-envify "^1.3.1"
+    path-to-regexp "^1.7.0"
+    prop-types "^15.6.2"
+    react-is "^16.6.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
 
 react-scripts-ts@3.1.0:
   version "3.1.0"
@@ -6199,6 +6274,11 @@ resolve-dir@^1.0.0:
 resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
+
+resolve-pathname@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-2.2.0.tgz#7e9ae21ed815fd63ab189adeee64dc831eefa879"
+  integrity sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg==
 
 resolve-url@^0.2.1:
   version "0.2.1"
@@ -6907,7 +6987,12 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
-tiny-warning@^1.0.2:
+tiny-invariant@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.0.4.tgz#346b5415fd93cb696b0c4e8a96697ff590f92463"
+  integrity sha512-lMhRd/djQJ3MoaHEBrw8e2/uM4rs9YMNk0iOr8rHQ0QdbM7D4l0gFl3szKdeixrlyfm9Zqi4dxHCM2qVG8ND5g==
+
+tiny-warning@^1.0.0, tiny-warning@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.2.tgz#1dfae771ee1a04396bdfde27a3adcebc6b648b28"
 
@@ -7321,6 +7406,11 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+value-equal@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-0.4.0.tgz#c5bdd2f54ee093c04839d71ce2e4758a6890abc7"
+  integrity sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw==
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
This pull request is part of the work to make clicking to other pages work in conjunction with the current incorporation pages. To achieve this, I've added "React-router-dom", which allows the frontend to expand with the capacity of accepting more pages.

- Added "react-router-dom" and "@types/react-router-dom"
- Added an 404 error page template
- Refactored pages and locate them under the folder "src/pages". Respecting the OOP design pattern.